### PR TITLE
Add Jupyter notebook to fetch Docker image and launch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,6 +190,20 @@ with client.audio.speech.with_streaming_response.create(
 
 </details>
 
+<details>
+<summary>Launch on Google Colab using Jupyter Notebook</summary>
+
+1. **Open the Jupyter Notebook**:
+   - Open the `launch_kokoro.ipynb` file in your Jupyter environment.
+
+2. **Run the Notebook**:
+   - Execute each cell in the notebook to fetch the Docker image, launch it, and obtain the API URL.
+
+3. **Use the API URL**:
+   - Use the provided API URL in your local SillyTavern instance to connect to the FastAPI server running on Google Colab.
+
+</details>
+
 ## Features 
 <details>
 <summary>OpenAI-Compatible Speech Endpoint</summary>

--- a/launch_kokoro.ipynb
+++ b/launch_kokoro.ipynb
@@ -1,0 +1,110 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Launch Kokoro FastAPI on Google Colab\n",
+    "\n",
+    "This notebook will fetch the Docker image, launch it, and provide an API URL for use in SillyTavern."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Install docker-py\n",
+    "!pip install docker"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Import necessary libraries\n",
+    "import docker\n",
+    "import time"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Initialize Docker client\n",
+    "client = docker.from_env()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Pull the Docker image\n",
+    "image = client.images.pull('ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.2')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Run the Docker container\n",
+    "container = client.containers.run(\n",
+    "    'ghcr.io/remsky/kokoro-fastapi-cpu:v0.2.2',\n",
+    "    ports={'8880/tcp': 8880},\n",
+    "    detach=True\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Wait for the container to start\n",
+    "time.sleep(10)  # Adjust the sleep time if necessary"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Provide the API URL\n",
+    "api_url = 'http://localhost:8880'\n",
+    "print(f'API URL: {api_url}')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.12"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
Add a Jupyter notebook to fetch Docker image, launch it, and provide API URL for SillyTavern.

* **launch_kokoro.ipynb**:
  - Add a Jupyter notebook that fetches the Docker image, launches it, and provides an API URL.
  - Install `docker-py` and import necessary libraries.
  - Initialize Docker client and pull the Docker image.
  - Run the Docker container and wait for it to start.
  - Provide the API URL `http://localhost:8880`.

* **README.md**:
  - Add instructions on how to use the Jupyter notebook to launch the Docker container and obtain the API URL.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CY83R-3X71NC710N/Kokoro-FastAPI/pull/2?shareId=9dc86264-f162-43e5-b421-d84ad4fc6086).