### PR TITLE
Update URL in launch_kokoro.ipynb to use Pinggy

### DIFF
--- a/launch_kokoro.ipynb
+++ b/launch_kokoro.ipynb
@@ -15,8 +15,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Install docker-py\n",
-    "!pip install docker"
+    "# Install docker-py and pinggy\n",
+    "!pip install docker pinggy"
    ]
   },
   {
@@ -27,7 +27,8 @@
    "source": [
     "# Import necessary libraries\n",
     "import docker\n",
-    "import time"
+    "import time\n",
+    "from pinggy import Pinggy"
    ]
   },
   {
@@ -80,8 +81,10 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Provide the API URL\n",
-    "api_url = 'http://localhost:8880'\n",
+    "# Obtain a public URL using Pinggy\n",
+    "pinggy = Pinggy()\n",
+    "public_url = pinggy.create_tunnel(8880)\n",
+    "api_url = public_url['url']\n",
     "print(f'API URL: {api_url}')"
    ]
   }


### PR DESCRIPTION
Update the `launch_kokoro.ipynb` file to use a cloud-based URL service for external access.

* Install the `pinggy` library along with `docker-py`.
* Import the `Pinggy` class from the `pinggy` library.
* Replace the local URL with a public URL obtained from `pinggy` for the API.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CY83R-3X71NC710N/Kokoro-FastAPI/pull/3?shareId=22b0c8da-0da7-42ee-b184-b69f9fca5b1b).